### PR TITLE
Add simple travis test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+    -stable
+script: npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-    -stable
+    - stable
 script: npm run test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Javascript package for the [Constructor.io API](http://constructor.io/docs).  Constructor.io provides a lightning-fast, typo-tolerant autocomplete service that ranks your users' queries by popularity to let them find what they're looking for as quickly as possible.
 
+[![Build Status](https://travis-ci.org/Constructor-io/constructorio-javascript.svg?branch=master)](https://travis-ci.org/Constructor-io/constructorio-javascript)
+
 ## Installation
 
 With npm:


### PR DESCRIPTION
To complete setup, you'll want to create an account @ travis-ci.org using the Constructor-io github profile. Markdown link assumes travis doesn't map our capital profile to lowercase.