### PR TITLE
[CH6629] Synonyms support + tests

### DIFF
--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -406,7 +406,6 @@ ConstructorIO.prototype = {
       method: 'DELETE',
       url: this.makeUrl('synonym_groups'),
       auth: this.makeAuthToken(),
-      json: params,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -336,14 +336,14 @@ ConstructorIO.prototype = {
   /**
    * @description Modifies a synonym group for supplied id.
    */
-  updateSynonymGroup(params, callback) {
+  modifySynonymGroup(params, callback) {
     const json = clonedeep(params);
-    const { id } = json;
-    delete json.id;
+    const { group_id } = json;
+    delete json.group_id;
 
     request({
       method: 'PUT',
-      url: this.makeUrl(`synonym_groups/${id}`),
+      url: this.makeUrl(`synonym_groups/${group_id}`),
       auth: this.makeAuthToken(),
       json: params,
     }, (error, response) => {
@@ -385,12 +385,13 @@ ConstructorIO.prototype = {
    */
   getSynonymGroup(params, callback) {
     const json = clonedeep(params);
-    const { id, phrase } = json;
-    delete json.id;
+    const { group_id, phrase } = json;
+    delete json.group_id;
+    delete json.phrase;
 
     request({
       method: 'GET',
-      url: this.makeUrl(`synonym_groups/${id || phrase}`),
+      url: this.makeUrl(`synonym_groups/${group_id || phrase}`),
       auth: this.makeAuthToken(),
       json: params,
     }, (error, response) => {
@@ -401,7 +402,7 @@ ConstructorIO.prototype = {
   /**
    * @description Remove all synonym groups.
    */
-  deleteSynonymGroups(params, callback) {
+  removeSynonymGroups(params, callback) {
     request({
       method: 'DELETE',
       url: this.makeUrl('synonym_groups'),
@@ -415,14 +416,14 @@ ConstructorIO.prototype = {
   /**
    * @description Remove synonym group for supplied id.
    */
-  deleteSynonymGroup(params, callback) {
+  removeSynonymGroup(params, callback) {
     const json = clonedeep(params);
-    const { id } = json;
-    delete json.id;
+    const { group_id } = json;
+    delete json.group_id;
 
     request({
       method: 'DELETE',
-      url: this.makeUrl(`synonym_groups/${id}`),
+      url: this.makeUrl(`synonym_groups/${group_id}`),
       auth: this.makeAuthToken(),
       json: params,
     }, (error, response) => {

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -352,7 +352,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Retrieves all synonym groups.
+   * @description Retrieves all synonym groups optionally filtered by phrase
    */
   getSynonymGroups(params, callback) {
     const { num_results_per_page, phrase, page } = params;
@@ -381,17 +381,16 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Retrieves synonym group for supplied id or phrase.
+   * @description Retrieves synonym group for supplied id.
    */
   getSynonymGroup(params, callback) {
     const json = clonedeep(params);
-    const { group_id, phrase } = json;
+    const { group_id } = json;
     delete json.group_id;
-    delete json.phrase;
 
     request({
       method: 'GET',
-      url: this.makeUrl(`synonym_groups/${group_id || phrase}`),
+      url: this.makeUrl(`synonym_groups/${group_id}`),
       auth: this.makeAuthToken(),
       json: params,
     }, (error, response) => {

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -319,6 +319,116 @@ ConstructorIO.prototype = {
     });
   },
 
+  /**
+   * @description Adds a synonym group.
+   */
+  addSynonymGroup(params, callback) {
+    request({
+      method: 'POST',
+      url: this.makeUrl('synonym_groups'),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Modifies a synonym group for supplied id.
+   */
+  updateSynonymGroup(params, callback) {
+    const json = clonedeep(params);
+    const { id } = json;
+    delete json.id;
+
+    request({
+      method: 'PUT',
+      url: this.makeUrl(`synonym_groups/${id}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Retrieves all synonym groups.
+   */
+  getSynonymGroups(params, callback) {
+    const { num_results_per_page, phrase, page } = params;
+    const qsParams = {};
+
+    if (num_results_per_page) {
+      qsParams.num_results_per_page = num_results_per_page;
+    }
+
+    if (phrase) {
+      qsParams.phrase = phrase;
+    }
+
+    if (page) {
+      qsParams.page = page;
+    }
+
+    request({
+      method: 'GET',
+      url: this.makeUrl('synonym_groups'),
+      auth: this.makeAuthToken(),
+      qs: qsParams,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Retrieves synonym group for supplied id or phrase.
+   */
+  getSynonymGroup(params, callback) {
+    const json = clonedeep(params);
+    const { id, phrase } = json;
+    delete json.id;
+
+    request({
+      method: 'GET',
+      url: this.makeUrl(`synonym_groups/${id || phrase}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Remove all synonym groups.
+   */
+  deleteSynonymGroups(params, callback) {
+    request({
+      method: 'DELETE',
+      url: this.makeUrl('synonym_groups'),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Remove synonym group for supplied id.
+   */
+  deleteSynonymGroup(params, callback) {
+    const json = clonedeep(params);
+    const { id } = json;
+    delete json.id;
+
+    request({
+      method: 'DELETE',
+      url: this.makeUrl(`synonym_groups/${id}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
 };
 
 module.exports = ConstructorIO;

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -253,6 +253,119 @@ describe('ConstructorIO - Synonym Groups', () => {
     });
   });
 
+  describe.only('getSynonymGroups', () => {
+    let addedSynonymGroupIds = [];
+
+    before((done) => {
+      const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
+
+      // Create test synonym groups for use in tests
+      Promise.all(addPromiseList).then((results) => {
+        results.forEach((result) => addedSynonymGroupIds.push(result.group_id));
+        done();
+      }).catch((err) => {
+        console.warn('Test synonym groups within `getSynonymGroups` could not be created');
+        console.warn(err);
+        done();
+      });
+    });
+
+    after((done) => {
+      const removePromiseList = [];
+
+      addedSynonymGroupIds.forEach((groupId) => {
+        removePromiseList.push(removeTestSynonymGroup(groupId));
+      });
+
+      // Remove test synonym groups for use in tests
+      Promise.all(removePromiseList).then(() => {
+        done();
+      }).catch((err) => {
+        console.warn('Test synonym groups within `getSynonymGroups` could not be created');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should retrieve a listing of all groups', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroups({}, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('synonym_groups').an('array').length(3);
+        done();
+      });
+    });
+
+    it('should retrieve a listing of one group when supplying num results per page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroups({
+        num_results_per_page: 1
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('synonym_groups').an('array').length(1);
+        done();
+      });
+    });
+
+    it('should return error when retrieving a listing of groups with invalid num results per page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroups({
+        num_results_per_page: 'abc'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'num_results_per_page must be an integer');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return no results when retrieving a listing of groups with invalid num results per page and page combination', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroups({
+        num_results_per_page: 1,
+        page: 7,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('synonym_groups').an('array').length(0);
+        done();
+      });
+    });
+
+    it('should return error when retrieving a listing of groups with invalid page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroups({
+        page: 'abc'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'page must be an integer');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when getting group listing with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.getSynonymGroups({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
   describe('removeSynonymGroup', () => {
     let addedSynonymGroupId = null;
 

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -1,8 +1,6 @@
-/* eslint-disable prefer-destructuring, no-unused-expressions */
+/* eslint-disable prefer-destructuring, no-unused-expressions, no-console, max-nested-callbacks */
 
 const expect = require('chai').expect;
-const deepfreeze = require('deepfreeze');
-const uuidv1 = require('uuid/v1');
 const Constructorio = require('../lib/constructorio');
 
 const testConfig = {
@@ -18,8 +16,8 @@ function addTestSynonymGroup() {
     constructorio.addSynonymGroup({
       synonyms: [
         `${Math.random().toString(36).substring(2, 15)}`,
-        `${Math.random().toString(36).substring(2, 15)}`
-      ]
+        `${Math.random().toString(36).substring(2, 15)}`,
+      ],
     }, (err, response) => {
       if (err) {
         return reject(err);
@@ -36,7 +34,7 @@ function removeTestSynonymGroup(id) {
 
   return new Promise((resolve, reject) => {
     constructorio.removeSynonymGroup({
-      group_id: id
+      group_id: id,
     }, (err, response) => {
       if (err) {
         return reject(err);
@@ -64,7 +62,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.addSynonymGroup({
-        synonyms: ['0% milk', 'skim milk', 'nonfat milk']
+        synonyms: ['0% milk', 'skim milk', 'nonfat milk'],
       }, (err, response) => {
         addedSynonymGroupId = response.group_id;
 
@@ -79,7 +77,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.addSynonymGroup({
-        synonyms: ['0% milk', 'skim milk', 'nonfat milk']
+        synonyms: ['0% milk', 'skim milk', 'nonfat milk'],
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'An identical or superset synonym group already exists.');
@@ -92,7 +90,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.addSynonymGroup({
-        synonyms: []
+        synonyms: [],
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'This method requires at least one synonym passed in JSON. See the docs for more details.');
@@ -105,7 +103,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.addSynonymGroup({
-        synonyms: 'abc'
+        synonyms: 'abc',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'You must supply the "synonyms" parameter, and it must be of type "array".');
@@ -132,7 +130,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       });
 
       constructorio.addSynonymGroup({
-        synonyms: ['0% milk', 'skim milk', 'nonfat milk']
+        synonyms: ['0% milk', 'skim milk', 'nonfat milk'],
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
@@ -146,15 +144,18 @@ describe('ConstructorIO - Synonym Groups', () => {
     let addedSynonymGroupId = null;
 
     before((done) => {
-      // Create test synonym group for use in tests
-      addTestSynonymGroup().then((response) => {
-        addedSynonymGroupId = response.group_id
-        done();
-      }).catch((err) => {
-        console.warn('Test synonym group within `modifySynonymGroup` could not be created');
-        console.warn(err);
-        done();
-      });
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        // Create test synonym group for use in tests
+        addTestSynonymGroup().then((response) => {
+          addedSynonymGroupId = response.group_id;
+          done();
+        }).catch((err) => {
+          console.warn('Test synonym group within `modifySynonymGroup` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
     });
 
     after((done) => {
@@ -173,7 +174,7 @@ describe('ConstructorIO - Synonym Groups', () => {
 
       constructorio.modifySynonymGroup({
         group_id: addedSynonymGroupId,
-        synonyms: ['foo', 'bar', 'baz']
+        synonyms: ['foo', 'bar', 'baz'],
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.undefined;
@@ -186,7 +187,7 @@ describe('ConstructorIO - Synonym Groups', () => {
 
       constructorio.modifySynonymGroup({
         group_id: 1,
-        synonyms: ['foo', 'bar', 'baz']
+        synonyms: ['foo', 'bar', 'baz'],
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
@@ -200,7 +201,7 @@ describe('ConstructorIO - Synonym Groups', () => {
 
       constructorio.modifySynonymGroup({
         group_id: addedSynonymGroupId,
-        synonyms: 'foo'
+        synonyms: 'foo',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'You must supply the "synonyms" parameter, and it must be of type "array".');
@@ -226,7 +227,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.modifySynonymGroup({
-        synonyms: ['foo', 'bar', 'baz']
+        synonyms: ['foo', 'bar', 'baz'],
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
@@ -243,7 +244,7 @@ describe('ConstructorIO - Synonym Groups', () => {
 
       constructorio.modifySynonymGroup({
         group_id: addedSynonymGroupId,
-        synonyms: ['foo', 'bar', 'baz']
+        synonyms: ['foo', 'bar', 'baz'],
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
@@ -254,21 +255,24 @@ describe('ConstructorIO - Synonym Groups', () => {
   });
 
   describe('getSynonymGroups', () => {
-    let addedSynonymGroupIds = [];
+    const addedSynonymGroupIds = [];
     let firstPhrase = '';
 
     before((done) => {
-      const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
 
-      // Create test synonym groups for use in tests
-      Promise.all(addPromiseList).then((results) => {
-        results.forEach((result) => addedSynonymGroupIds.push(result.group_id));
-        done();
-      }).catch((err) => {
-        console.warn('Test synonym groups within `getSynonymGroups` could not be created');
-        console.warn(err);
-        done();
-      });
+        // Create test synonym groups for use in tests
+        Promise.all(addPromiseList).then((results) => {
+          results.forEach(result => addedSynonymGroupIds.push(result.group_id));
+          done();
+        }).catch((err) => {
+          console.warn('Test synonym groups within `getSynonymGroups` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
     });
 
     after((done) => {
@@ -309,7 +313,7 @@ describe('ConstructorIO - Synonym Groups', () => {
 
       // Note: Result set is not being checked for match as phrase can take many seconds to be indexed / returned
       constructorio.getSynonymGroups({
-        phrase: firstPhrase
+        phrase: firstPhrase,
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -322,7 +326,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getSynonymGroups({
-        phrase: 'mallorca'
+        phrase: 'mallorca',
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -334,12 +338,13 @@ describe('ConstructorIO - Synonym Groups', () => {
     it('should retrieve a listing of one group when supplying num results per page parameter', (done) => {
       const constructorio = new Constructorio(testConfig);
 
+      // Note: Result set is not being checked for match as phrase can take many seconds to be indexed / returned
       constructorio.getSynonymGroups({
-        num_results_per_page: 1
+        num_results_per_page: 1,
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
-        expect(response).to.have.property('synonym_groups').an('array').length(1);
+        expect(response).to.have.property('synonym_groups').an('array');
         done();
       });
     });
@@ -348,7 +353,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getSynonymGroups({
-        num_results_per_page: 'abc'
+        num_results_per_page: 'abc',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'num_results_per_page must be an integer');
@@ -375,7 +380,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getSynonymGroups({
-        page: 'abc'
+        page: 'abc',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'page must be an integer');
@@ -403,15 +408,18 @@ describe('ConstructorIO - Synonym Groups', () => {
     let addedSynonymGroupId = null;
 
     before((done) => {
-      // Create test synonym group for use in tests
-      addTestSynonymGroup().then((response) => {
-        addedSynonymGroupId = response.group_id
-        done();
-      }).catch((err) => {
-        console.warn('Test synonym group within `getSynonymGroup` could not be created');
-        console.warn(err);
-        done();
-      });
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        // Create test synonym group for use in tests
+        addTestSynonymGroup().then((response) => {
+          addedSynonymGroupId = response.group_id;
+          done();
+        }).catch((err) => {
+          console.warn('Test synonym group within `getSynonymGroup` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
     });
 
     after((done) => {
@@ -429,7 +437,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getSynonymGroup({
-        group_id: addedSynonymGroupId
+        group_id: addedSynonymGroupId,
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -479,20 +487,23 @@ describe('ConstructorIO - Synonym Groups', () => {
   });
 
   describe('removeSynonymGroups', () => {
-    let addedSynonymGroupIds = [];
+    const addedSynonymGroupIds = [];
 
     before((done) => {
-      const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
 
-      // Create test synonym groups for use in tests
-      Promise.all(addPromiseList).then((results) => {
-        results.forEach((result) => addedSynonymGroupIds.push(result.group_id));
-        done();
-      }).catch((err) => {
-        console.warn('Test synonym groups within `getSynonymGroups` could not be created');
-        console.warn(err);
-        done();
-      });
+        // Create test synonym groups for use in tests
+        Promise.all(addPromiseList).then((results) => {
+          results.forEach(result => addedSynonymGroupIds.push(result.group_id));
+          done();
+        }).catch((err) => {
+          console.warn('Test synonym groups within `getSynonymGroups` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
     });
 
     it('should start removal of all groups', (done) => {
@@ -519,7 +530,7 @@ describe('ConstructorIO - Synonym Groups', () => {
           expect(response).to.have.property('message', 'It appears there aren\'t any items to delete');
           done();
         });
-      }, 2000);
+      }, 3000);
     });
 
     it('should return error when removing groups with an invalid key/token', (done) => {
@@ -542,26 +553,28 @@ describe('ConstructorIO - Synonym Groups', () => {
     let addedSynonymGroupId = null;
 
     before((done) => {
-      // Create test synonym group for use in tests
-      addTestSynonymGroup().then((response) => {
-        addedSynonymGroupId = response.group_id
-        done();
-      }).catch((err) => {
-        console.warn('Test synonym group within `removeSynonymGroup` could not be created');
-        console.warn(err);
-        done();
-      });
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        // Create test synonym group for use in tests
+        addTestSynonymGroup().then((response) => {
+          addedSynonymGroupId = response.group_id;
+          done();
+        }).catch((err) => {
+          console.warn('Test synonym group within `removeSynonymGroup` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
     });
 
     it('should remove a group when supplying a valid group id', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.removeSynonymGroup({
-        group_id: addedSynonymGroupId
+        group_id: addedSynonymGroupId,
       }, (err, response) => {
         expect(err).to.be.undefined;
-        expect(response).to.be.an('object');
-        expect(response).to.have.property('message', '');
+        expect(response).to.be.undefined;
         done();
       });
     });
@@ -570,7 +583,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.removeSynonymGroup({
-        group_id: addedSynonymGroupId
+        group_id: addedSynonymGroupId,
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
@@ -583,7 +596,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.removeSynonymGroup({
-        group_id: 1
+        group_id: 1,
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
@@ -596,7 +609,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.removeSynonymGroup({
-        group_id: 'abc'
+        group_id: 'abc',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
@@ -623,7 +636,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       });
 
       constructorio.removeSynonymGroup({
-        group_id: addedSynonymGroupId
+        group_id: addedSynonymGroupId,
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
@@ -633,4 +646,3 @@ describe('ConstructorIO - Synonym Groups', () => {
     });
   });
 });
-

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -462,8 +462,7 @@ describe('ConstructorIO - Synonym Groups', () => {
     it('should return error when retrieving a group without supplying a group id', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.getSynonymGroup({
-      }, (err, response) => {
+      constructorio.getSynonymGroup({}, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
         expect(response).to.be.undefined;
@@ -509,8 +508,7 @@ describe('ConstructorIO - Synonym Groups', () => {
     it('should start removal of all groups', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.removeSynonymGroups({
-      }, (err, response) => {
+      constructorio.removeSynonymGroups({}, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
         expect(response).to.have.property('message', 'We\'ve started deleting all of your synonym groups. This may take some time to complete.');
@@ -523,8 +521,7 @@ describe('ConstructorIO - Synonym Groups', () => {
 
       // It can take some time for the system to remove all items
       setTimeout(() => {
-        constructorio.removeSynonymGroups({
-        }, (err, response) => {
+        constructorio.removeSynonymGroups({}, (err, response) => {
           expect(err).to.be.undefined;
           expect(response).to.be.an('object');
           expect(response).to.have.property('message', 'It appears there aren\'t any items to delete');
@@ -539,8 +536,7 @@ describe('ConstructorIO - Synonym Groups', () => {
         apiKey: 'bad-key',
       });
 
-      constructorio.removeSynonymGroups({
-      }, (err, response) => {
+      constructorio.removeSynonymGroups({}, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
         expect(response).to.be.undefined;

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -478,6 +478,66 @@ describe('ConstructorIO - Synonym Groups', () => {
     });
   });
 
+  describe('removeSynonymGroups', () => {
+    let addedSynonymGroupIds = [];
+
+    before((done) => {
+      const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
+
+      // Create test synonym groups for use in tests
+      Promise.all(addPromiseList).then((results) => {
+        results.forEach((result) => addedSynonymGroupIds.push(result.group_id));
+        done();
+      }).catch((err) => {
+        console.warn('Test synonym groups within `getSynonymGroups` could not be created');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should start removal of all groups', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeSynonymGroups({
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('message', 'We\'ve started deleting all of your synonym groups. This may take some time to complete.');
+        done();
+      });
+    });
+
+    it('should notify that all groups have already been deleted', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      // It can take some time for the system to remove all items
+      setTimeout(() => {
+        constructorio.removeSynonymGroups({
+        }, (err, response) => {
+          expect(err).to.be.undefined;
+          expect(response).to.be.an('object');
+          expect(response).to.have.property('message', 'It appears there aren\'t any items to delete');
+          done();
+        });
+      }, 2000);
+    });
+
+    it('should return error when removing groups with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.removeSynonymGroups({
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
   describe('removeSynonymGroup', () => {
     let addedSynonymGroupId = null;
 

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -1,0 +1,351 @@
+/* eslint-disable prefer-destructuring, no-unused-expressions */
+
+const expect = require('chai').expect;
+const deepfreeze = require('deepfreeze');
+const uuidv1 = require('uuid/v1');
+const Constructorio = require('../lib/constructorio');
+
+const testConfig = {
+  apiToken: 'YSOxV00F0Kk2R0KnPQN8',
+  apiKey: 'ZqXaOfXuBWD4s3XzCI1q',
+};
+
+// Helper method - create synonym group with random synonyms
+function addTestSynonymGroup() {
+  const constructorio = new Constructorio(testConfig);
+
+  return new Promise((resolve, reject) => {
+    constructorio.addSynonymGroup({
+      synonyms: [
+        `${Math.random().toString(36).substring(2, 15)}`,
+        `${Math.random().toString(36).substring(2, 15)}`
+      ]
+    }, (err, response) => {
+      if (err) {
+        return reject(err);
+      }
+
+      return resolve(response);
+    });
+  });
+}
+
+// Helper method - remove synonym group for specified id
+function removeTestSynonymGroup(id) {
+  const constructorio = new Constructorio(testConfig);
+
+  return new Promise((resolve, reject) => {
+    constructorio.removeSynonymGroup({
+      group_id: id
+    }, (err, response) => {
+      if (err) {
+        return reject(err);
+      }
+
+      return resolve(response);
+    });
+  });
+}
+
+describe('ConstructorIO - Synonym Groups', () => {
+  describe('addSynonymGroup', () => {
+    let addedSynonymGroupId = null;
+
+    after((done) => {
+      // Clean up - remove synonym group created for tests
+      removeTestSynonymGroup(addedSynonymGroupId).then(done).catch((err) => {
+        console.warn('Created test synonym group within `addSynonymGroup` could not be removed');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should return a group id when adding a group with synonyms', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addSynonymGroup({
+        synonyms: ['0% milk', 'skim milk', 'nonfat milk']
+      }, (err, response) => {
+        addedSynonymGroupId = response.group_id;
+
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('group_id').that.is.a('number');
+        done();
+      });
+    });
+
+    it('should return an error when adding a group with the same synonyms', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addSynonymGroup({
+        synonyms: ['0% milk', 'skim milk', 'nonfat milk']
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'An identical or superset synonym group already exists.');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when adding a group with no synonyms', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addSynonymGroup({
+        synonyms: []
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'This method requires at least one synonym passed in JSON. See the docs for more details.');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when adding a group with synonyms of incorrect type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addSynonymGroup({
+        synonyms: 'abc'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'You must supply the "synonyms" parameter, and it must be of type "array".');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when adding a group without synonyms property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addSynonymGroup({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'You must supply the "synonyms" parameter, and it must be of type "array".');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when adding a group with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.addSynonymGroup({
+        synonyms: ['0% milk', 'skim milk', 'nonfat milk']
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('modifySynonymGroup', () => {
+    let addedSynonymGroupId = null;
+
+    before((done) => {
+      // Create test synonym group for use in tests
+      addTestSynonymGroup().then((response) => {
+        addedSynonymGroupId = response.group_id
+        done();
+      }).catch((err) => {
+        console.warn('Test synonym group within `modifySynonymGroup` could not be created');
+        console.warn(err);
+        done();
+      });
+    });
+
+    after((done) => {
+      // Clean up - remove synonym group created for tests
+      removeTestSynonymGroup(addedSynonymGroupId).then(() => {
+        done();
+      }).catch((err) => {
+        console.warn('Created test synonym group within `modifySynonymGroup` could not be removed');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should modify a group when supplying a valid group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifySynonymGroup({
+        group_id: addedSynonymGroupId,
+        synonyms: ['foo', 'bar', 'baz']
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifySynonymGroup({
+        group_id: 1,
+        synonyms: ['foo', 'bar', 'baz']
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying synonyms of incorrect type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifySynonymGroup({
+        group_id: addedSynonymGroupId,
+        synonyms: 'foo'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'You must supply the "synonyms" parameter, and it must be of type "array".');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when modifying a group without synonyms property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifySynonymGroup({
+        group_id: addedSynonymGroupId,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'You must supply the "synonyms" parameter, and it must be of type "array".');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when modifying a group without group id property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifySynonymGroup({
+        synonyms: ['foo', 'bar', 'baz']
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when modifying a group with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.modifySynonymGroup({
+        group_id: addedSynonymGroupId,
+        synonyms: ['foo', 'bar', 'baz']
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('removeSynonymGroup', () => {
+    let addedSynonymGroupId = null;
+
+    before((done) => {
+      // Create test synonym group for use in tests
+      addTestSynonymGroup().then((response) => {
+        addedSynonymGroupId = response.group_id
+        done();
+      }).catch((err) => {
+        console.warn('Test synonym group within `removeSynonymGroup` could not be created');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should remove a group when supplying a valid group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeSynonymGroup({
+        group_id: addedSynonymGroupId
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('message', '');
+        done();
+      });
+    });
+
+    it('should return an error when supplying a valid group id that has already been removed', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeSynonymGroup({
+        group_id: addedSynonymGroupId
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeSynonymGroup({
+        group_id: 1
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying a group id of invalid type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeSynonymGroup({
+        group_id: 'abc'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when not supplying a group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeSynonymGroup({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when adding a group with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.removeSynonymGroup({
+        group_id: addedSynonymGroupId
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+});
+

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -253,7 +253,7 @@ describe('ConstructorIO - Synonym Groups', () => {
     });
   });
 
-  describe.only('getSynonymGroups', () => {
+  describe('getSynonymGroups', () => {
     let addedSynonymGroupIds = [];
     let firstPhrase = '';
 
@@ -391,6 +391,85 @@ describe('ConstructorIO - Synonym Groups', () => {
       });
 
       constructorio.getSynonymGroups({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('getSynonymGroup', () => {
+    let addedSynonymGroupId = null;
+
+    before((done) => {
+      // Create test synonym group for use in tests
+      addTestSynonymGroup().then((response) => {
+        addedSynonymGroupId = response.group_id
+        done();
+      }).catch((err) => {
+        console.warn('Test synonym group within `getSynonymGroup` could not be created');
+        console.warn(err);
+        done();
+      });
+    });
+
+    after((done) => {
+      // Clean up - remove synonym group created for tests
+      removeTestSynonymGroup(addedSynonymGroupId).then(() => {
+        done();
+      }).catch((err) => {
+        console.warn('Created test synonym group within `getSynonymGroup` could not be removed');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should retrieve a group for supplied valid group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroup({
+        group_id: addedSynonymGroupId
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('synonym_groups').an('array').length(1);
+        done();
+      });
+    });
+
+    it('should return error when retrieving a group with non-existent group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroup({
+        group_id: 1,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when retrieving a group without supplying a group id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroup({
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no synonym group with this id associated with your autocomplete_key');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when getting group listing with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.getSynonymGroup({}, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
         expect(response).to.be.undefined;

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -255,6 +255,7 @@ describe('ConstructorIO - Synonym Groups', () => {
 
   describe.only('getSynonymGroups', () => {
     let addedSynonymGroupIds = [];
+    let firstPhrase = '';
 
     before((done) => {
       const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
@@ -291,9 +292,41 @@ describe('ConstructorIO - Synonym Groups', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getSynonymGroups({}, (err, response) => {
+        firstPhrase = response.synonym_groups
+          && response.synonym_groups[0]
+          && response.synonym_groups[0].synonyms
+          && response.synonym_groups[0].synonyms[0];
+
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
         expect(response).to.have.property('synonym_groups').an('array').length(3);
+        done();
+      });
+    });
+
+    it('should retrieve a listing of one group when supplying phrase parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      // Note: Result set is not being checked for match as phrase can take many seconds to be indexed / returned
+      constructorio.getSynonymGroups({
+        phrase: firstPhrase
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('synonym_groups').an('array');
+        done();
+      });
+    });
+
+    it('should return error when retrieving a listing of groups with non-existent phrase parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getSynonymGroups({
+        phrase: 'mallorca'
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('synonym_groups').an('array').length(0);
         done();
       });
     });


### PR DESCRIPTION
Added methods to support the following [synonym REST endpoints](https://docs.constructor.io/rest-api.html#synonyms):

addSynonymGroup => POST https://ac.cnstrc.com/v1/synonym_groups
modifySynonymGroup => PUT https://ac.cnstrc.com/v1/synonym_groups/[group_id]
getSynonymGroups => GET https://ac.cnstrc.com/v1/synonym_groups
getSynonymGroup => GET https://ac.cnstrc.com/v1/synonym_groups/[group_id]
removeSynonymGroups => DELETE https://ac.cnstrc.com/v1/synonym_groups
removeSynonymGroup => DELETE https://ac.cnstrc.com/v1/synonym_groups/[group_id]

33 tests added covering all methods and associated parameters listed above, executing in ~41 seconds.