### PR TITLE
[CH6809] Redirects support + tests

### DIFF
--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -497,7 +497,7 @@ ConstructorIO.prototype = {
   /**
    * @description Completely updates a redirect rule for supplied id.
    */
-  setRedirectRule(params, callback) {
+  modifyRedirectRule(params, callback) {
     const json = clonedeep(params);
     const { redirect_rule_id } = json;
     delete json.redirect_rule_id;
@@ -515,7 +515,7 @@ ConstructorIO.prototype = {
   /**
    * @description Partially updates a redirect rule for supplied id.
    */
-  modifyRedirectRule(params, callback) {
+  updateRedirectRule(params, callback) {
     const json = clonedeep(params);
     const { redirect_rule_id } = json;
     delete json.redirect_rule_id;

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -482,7 +482,7 @@ ConstructorIO.prototype = {
   getRedirectRule(params, callback) {
     const json = clonedeep(params);
     const { redirect_rule_id } = json;
-    delete json.group_id;
+    delete json.redirect_rule_id;
 
     request({
       method: 'GET',

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -345,7 +345,7 @@ ConstructorIO.prototype = {
       method: 'PUT',
       url: this.makeUrl(`synonym_groups/${group_id}`),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -392,7 +392,7 @@ ConstructorIO.prototype = {
       method: 'GET',
       url: this.makeUrl(`synonym_groups/${group_id}`),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -423,7 +423,7 @@ ConstructorIO.prototype = {
       method: 'DELETE',
       url: this.makeUrl(`synonym_groups/${group_id}`),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -488,7 +488,7 @@ ConstructorIO.prototype = {
       method: 'GET',
       url: this.makeUrl(`redirect_rules/${redirect_rule_id}`),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -499,14 +499,14 @@ ConstructorIO.prototype = {
    */
   setRedirectRule(params, callback) {
     const json = clonedeep(params);
-    const { group_id } = json;
-    delete json.group_id;
+    const { redirect_rule_id } = json;
+    delete json.redirect_rule_id;
 
     request({
       method: 'PUT',
-      url: this.makeUrl(`redirect_rules/${group_id}`),
+      url: this.makeUrl(`redirect_rules/${redirect_rule_id}`),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -517,14 +517,14 @@ ConstructorIO.prototype = {
    */
   modifyRedirectRule(params, callback) {
     const json = clonedeep(params);
-    const { group_id } = json;
-    delete json.group_id;
+    const { redirect_rule_id } = json;
+    delete json.redirect_rule_id;
 
     request({
       method: 'PATCH',
-      url: this.makeUrl(`redirect_rules/${group_id}`),
+      url: this.makeUrl(`redirect_rules/${redirect_rule_id}`),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -542,7 +542,7 @@ ConstructorIO.prototype = {
       method: 'DELETE',
       url: this.makeUrl(`redirect_rules/${redirect_rule_id}`),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -319,6 +319,124 @@ ConstructorIO.prototype = {
     });
   },
 
+  /**
+   * @description Creates a redirect rule.
+   */
+  addRedirectRule(params, callback) {
+    request({
+      method: 'POST',
+      url: this.makeUrl('redirect_rules'),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Retrieves all redirect rules optionally filtered by query or status.
+   */
+  getRedirectRules(params, callback) {
+    const { num_results_per_page, page, query, status } = params;
+    const qsParams = {};
+
+    if (num_results_per_page) {
+      qsParams.num_results_per_page = num_results_per_page;
+    }
+
+    if (page) {
+      qsParams.page = page;
+    }
+
+    if (query) {
+      qsParams.query = query;
+    }
+
+    if (status) {
+      qsParams.status = status;
+    }
+
+    request({
+      method: 'GET',
+      url: this.makeUrl('redirect_rules'),
+      auth: this.makeAuthToken(),
+      qs: qsParams,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Retrieves redirect rule for supplied id.
+   */
+  getRedirectRule(params, callback) {
+    const json = clonedeep(params);
+    const { redirect_rule_id } = json;
+    delete json.group_id;
+
+    request({
+      method: 'GET',
+      url: this.makeUrl(`redirect_rules/${redirect_rule_id}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Completely updates a redirect rule for supplied id.
+   */
+  setRedirectRule(params, callback) {
+    const json = clonedeep(params);
+    const { group_id } = json;
+    delete json.group_id;
+
+    request({
+      method: 'PUT',
+      url: this.makeUrl(`redirect_rules/${group_id}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Partially updates a redirect rule for supplied id.
+   */
+  modifyRedirectRule(params, callback) {
+    const json = clonedeep(params);
+    const { group_id } = json;
+    delete json.group_id;
+
+    request({
+      method: 'PATCH',
+      url: this.makeUrl(`redirect_rules/${group_id}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Remove redirect rule for supplied id.
+   */
+  removeRedirectRule(params, callback) {
+    const json = clonedeep(params);
+    const { redirect_rule_id } = json;
+    delete json.group_id;
+
+    request({
+      method: 'DELETE',
+      url: this.makeUrl(`redirect_rules/${redirect_rule_id}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
 };
 
 module.exports = ConstructorIO;

--- a/test/constructorio-redirects.js
+++ b/test/constructorio-redirects.js
@@ -545,7 +545,248 @@ describe('ConstructorIO - Redirect Rules', () => {
     });
   });
 
-  describe('setRedirectRule', () => {});
+  describe('setRedirectRule', () => {
+    let addedRedirectRuleId = null;
+
+    before((done) => {
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        // Create test redirect rule for use in tests
+        addTestRedirectRule().then((response) => {
+          addedRedirectRuleId = response.id;
+          done();
+        }).catch((err) => {
+          console.warn('Test synonym group within `setRedirectRule` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
+    });
+
+    after((done) => {
+      // Clean up - remove redirct rule created for tests
+      removeTestRedirectRule(addedRedirectRuleId).then(() => {
+        done();
+      }).catch((err) => {
+        console.warn('Created test synonym group within `setRedirectRule` could not be removed');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should return a redirect rule id when completely updating a redirect rule with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const updatedUrl = 'https://construct.or';
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        url: updatedUrl,
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'mallorca',
+          },
+          {
+            match_type: 'EXACT',
+            pattern: 'spain'
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('start_time');
+        expect(response).to.have.property('end_time');
+        expect(response).to.have.property('url', updatedUrl);
+        expect(response).to.have.property('matches').that.is.an('array').length(2);
+        expect(response).to.have.property('id').that.is.a('number', addedRedirectRuleId);
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule with an invalid match type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        url: 'https://constructor.io',
+        matches: [
+          {
+            match_type: 'NONSENSE',
+            pattern: 'constructor',
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'Invalid value for parameter: "matches[0].match_type"');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule without a url parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'constructor',
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'url is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule without a match type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        url: 'https://constructor.io',
+        matches: [
+          {
+            pattern: 'constructor'
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'matches[0].match_type is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule without a pattern', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        url: 'https://constructor.io',
+        matches: [
+          {
+            match_type: 'EXACT',
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'matches[0].pattern is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule with an invalid start time', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        start_time: 10,
+        url: 'https://constructor.io',
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'constructor'
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'start_time must be a datetime string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule with an invalid end time', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        end_time: 10,
+        url: 'https://constructor.io',
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'constructor'
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'end_time must be a datetime string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule with an invalid user segments parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        user_segments: 'abc',
+        url: 'https://constructor.io',
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'constructor'
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'user_segments must be a list');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when completely updating a redirect rule with invalid metadata', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        metadata: 'abc',
+        url: 'https://constructor.io',
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'constructor'
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'metadata must be a dictionary');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when getting group listing with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.setRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        url: 'https://constructor.io',
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'mallorca',
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
 
   describe('modifyRedirectRule', () => {});
 

--- a/test/constructorio-redirects.js
+++ b/test/constructorio-redirects.js
@@ -1,0 +1,99 @@
+/* eslint-disable prefer-destructuring, no-unused-expressions, no-console, max-nested-callbacks */
+
+const expect = require('chai').expect;
+const Constructorio = require('../lib/constructorio');
+
+const testConfig = {
+  apiToken: 'YSOxV00F0Kk2R0KnPQN8',
+  apiKey: 'ZqXaOfXuBWD4s3XzCI1q',
+};
+
+// Helper method - create redirect rule with random properties
+function addTestRedirectRule() {
+  const constructorio = new Constructorio(testConfig);
+
+  return new Promise((resolve, reject) => {
+    constructorio.addRedirectRule({
+      synonyms: [
+        `${Math.random().toString(36).substring(2, 15)}`,
+        `${Math.random().toString(36).substring(2, 15)}`,
+      ],
+    }, (err, response) => {
+      if (err) {
+        return reject(err);
+      }
+
+      return resolve(response);
+    });
+  });
+}
+
+// Helper method - remove redirect rule for specified id
+function removeTestRedirectRule(id) {
+  const constructorio = new Constructorio(testConfig);
+
+  return new Promise((resolve, reject) => {
+    constructorio.removeRedirectRule({
+      redirect_rule_id: id,
+    }, (err, response) => {
+      if (err) {
+        return reject(err);
+      }
+
+      return resolve(response);
+    });
+  });
+}
+
+describe('ConstructorIO - Redirect Rules', () => {
+  describe('addRedirectRule', () => {
+    let addedRedirectRuleId = null;
+
+    after((done) => {
+      // Clean up - remove synonym group created for tests
+      removeTestRedirectRule(addedRedirectRuleId).then(() => {
+        done();
+      }).catch((err) => {
+        console.warn('Created test redirect rule within `addRedirectRule` could not be removed');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should return a redirect rule id when adding a redirect rule with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const url = 'https://constructor.io';
+
+      constructorio.addRedirectRule({
+        url,
+        matches: [
+          {
+            match_type: 'EXACT',
+            pattern: 'constructor',
+          },
+        ],
+      }, (err, response) => {
+        addedRedirectRuleId = response.id;
+
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('start_time');
+        expect(response).to.have.property('end_time');
+        expect(response).to.have.property('url', url);
+        expect(response).to.have.property('matches').that.is.an('array').length(1);
+        expect(response).to.have.property('id').that.is.a('number');
+        done();
+      });
+    });
+  });
+
+  describe('getRedirectRules', () => {});
+
+  describe('getRedirectRule', () => {});
+
+  describe('setRedirectRule', () => {});
+
+  describe('modifyRedirectRule', () => {});
+
+  describe('removeRedirectRule', () => {});
+});

--- a/test/constructorio-redirects.js
+++ b/test/constructorio-redirects.js
@@ -539,7 +539,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     });
   });
 
-  describe('setRedirectRule', () => {
+  describe('modifyRedirectRule', () => {
     let addedRedirectRuleId = null;
 
     before((done) => {
@@ -561,7 +561,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
       const updatedUrl = 'https://construct.or';
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         url: updatedUrl,
         matches: [
@@ -589,7 +589,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule with an invalid match type', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         url: 'https://constructor.io',
         matches: [
@@ -609,7 +609,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule without a url parameter', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         matches: [
           {
@@ -628,7 +628,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule without a match type', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         url: 'https://constructor.io',
         matches: [
@@ -647,7 +647,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule without a pattern', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         url: 'https://constructor.io',
         matches: [
@@ -666,7 +666,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule with an invalid start time', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         start_time: 10,
         url: 'https://constructor.io',
@@ -687,7 +687,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule with an invalid end time', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         end_time: 10,
         url: 'https://constructor.io',
@@ -708,7 +708,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule with an invalid user segments parameter', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         user_segments: 'abc',
         url: 'https://constructor.io',
@@ -729,7 +729,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when completely updating a redirect rule with invalid metadata', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         metadata: 'abc',
         url: 'https://constructor.io',
@@ -753,7 +753,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         apiKey: 'bad-key',
       });
 
-      constructorio.setRedirectRule({
+      constructorio.modifyRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         url: 'https://constructor.io',
         matches: [
@@ -771,7 +771,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     });
   });
 
-  describe('modifyRedirectRule', () => {
+  describe('updateRedirectRule', () => {
     let addedRedirectRuleId = null;
 
     before((done) => {
@@ -793,7 +793,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
       const updatedUrl = 'https://construct.or';
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         url: updatedUrl,
       }, (err, response) => {
@@ -821,7 +821,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         },
       ];
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         matches: updatedMatches,
       }, (err, response) => {
@@ -835,7 +835,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
       const updatedStartTime = (new Date()).toISOString();
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         start_time: updatedStartTime,
       }, (err, response) => {
@@ -849,7 +849,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
       const updatedEndTime = (new Date()).toISOString();
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         end_time: updatedEndTime,
       }, (err, response) => {
@@ -863,7 +863,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
       const updatedUserSegments = ['foo', 'bar'];
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         user_segments: updatedUserSegments,
       }, (err, response) => {
@@ -877,7 +877,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
       const updatedMetadata = { foo: 'bar' };
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         metadata: updatedMetadata,
       }, (err, response) => {
@@ -893,7 +893,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         apiKey: 'bad-key',
       });
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         url: 'https://constructor.io',
       }, (err, response) => {
@@ -907,7 +907,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when setting the matches of a redirect rule without a matches type', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         matches: [
           {
@@ -925,7 +925,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when setting the matches of a redirect rule without a pattern', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         matches: [
           {
@@ -943,7 +943,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when setting an invalid start time of a redirect rule', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         start_time: 10,
       }, (err, response) => {
@@ -957,7 +957,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when setting a redirect rule with an an invalid start time', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         end_time: 10,
       }, (err, response) => {
@@ -971,7 +971,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when setting a redirect rule with an an invalid user settings parameter', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         user_segments: 'abc',
       }, (err, response) => {
@@ -985,7 +985,7 @@ describe('ConstructorIO - Redirect Rules', () => {
     it('should return error when setting a redirect rule with an an invalid metadata', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.modifyRedirectRule({
+      constructorio.updateRedirectRule({
         redirect_rule_id: addedRedirectRuleId,
         metadata: 'abc',
       }, (err, response) => {

--- a/test/constructorio-redirects.js
+++ b/test/constructorio-redirects.js
@@ -120,7 +120,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       });
     });
 
-    it('should return error when adding a redirect rule with an invalid match type', (done) => {
+    it('should return error when adding a redirect rule with an invalid matches type', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.addRedirectRule({
@@ -152,6 +152,19 @@ describe('ConstructorIO - Redirect Rules', () => {
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'url is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when adding a redirect rule without a matches parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addRedirectRule({
+        url: 'https://constructor.io',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'matches is a required field of type list');
         expect(response).to.be.undefined;
         done();
       });
@@ -273,7 +286,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       });
     });
 
-    it('should return error when getting group listing with an invalid key/token', (done) => {
+    it('should return error when getting a redirect rule with an invalid key/token', (done) => {
       const constructorio = new Constructorio({
         apiToken: 'bad-token',
         apiKey: 'bad-key',
@@ -454,7 +467,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       });
     });
 
-    it('should return error when getting group listing with an invalid key/token', (done) => {
+    it('should return error when getting a listing of redirect rules with an invalid key/token', (done) => {
       const constructorio = new Constructorio({
         apiToken: 'bad-token',
         apiKey: 'bad-key',
@@ -480,7 +493,7 @@ describe('ConstructorIO - Redirect Rules', () => {
           addedRedirectRuleId = response.id;
           done();
         }).catch((err) => {
-          console.warn('Test synonym group within `getRedirectRule` could not be created');
+          console.warn('Test redirect rule within `getRedirectRule` could not be created');
           console.warn(err);
           done();
         });
@@ -492,7 +505,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       removeTestRedirectRule(addedRedirectRuleId).then(() => {
         done();
       }).catch((err) => {
-        console.warn('Created test synonym group within `getRedirectRule` could not be removed');
+        console.warn('Created test redirect rule within `getRedirectRule` could not be removed');
         console.warn(err);
         done();
       });
@@ -515,7 +528,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       });
     });
 
-    it('should return error when retrieving a group with non-existent redirect rule id', (done) => {
+    it('should return error when retrieving a redircet rule with non-existent redirect rule id', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRule({
@@ -528,7 +541,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       });
     });
 
-    it('should return error when getting group listing with an invalid key/token', (done) => {
+    it('should return error when getting redirect rule listing with an invalid key/token', (done) => {
       const constructorio = new Constructorio({
         apiToken: 'bad-token',
         apiKey: 'bad-key',
@@ -556,7 +569,7 @@ describe('ConstructorIO - Redirect Rules', () => {
           addedRedirectRuleId = response.id;
           done();
         }).catch((err) => {
-          console.warn('Test synonym group within `setRedirectRule` could not be created');
+          console.warn('Test redirect rule within `setRedirectRule` could not be created');
           console.warn(err);
           done();
         });
@@ -568,13 +581,13 @@ describe('ConstructorIO - Redirect Rules', () => {
       removeTestRedirectRule(addedRedirectRuleId).then(() => {
         done();
       }).catch((err) => {
-        console.warn('Created test synonym group within `setRedirectRule` could not be removed');
+        console.warn('Created test redirect rule within `setRedirectRule` could not be removed');
         console.warn(err);
         done();
       });
     });
 
-    it('should return a redirect rule id when completely updating a redirect rule with valid properties', (done) => {
+    it('should return a redirect rule when completely updating a redirect rule with valid properties', (done) => {
       const constructorio = new Constructorio(testConfig);
       const updatedUrl = 'https://construct.or';
 
@@ -764,7 +777,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       });
     });
 
-    it('should return error when getting group listing with an invalid key/token', (done) => {
+    it('should return error when getting redirect rule listing with an invalid key/token', (done) => {
       const constructorio = new Constructorio({
         apiToken: 'bad-token',
         apiKey: 'bad-key',
@@ -788,7 +801,305 @@ describe('ConstructorIO - Redirect Rules', () => {
     });
   });
 
-  describe('modifyRedirectRule', () => {});
+  describe('modifyRedirectRule', () => {
+    let addedRedirectRuleId = null;
 
-  describe('removeRedirectRule', () => {});
+    before((done) => {
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        // Create test redirect rule for use in tests
+        addTestRedirectRule().then((response) => {
+          addedRedirectRuleId = response.id;
+          done();
+        }).catch((err) => {
+          console.warn('Test redirect rule within `modifyRedirectRule` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
+    });
+
+    after((done) => {
+      // Clean up - remove redirct rule created for tests
+      removeTestRedirectRule(addedRedirectRuleId).then(() => {
+        done();
+      }).catch((err) => {
+        console.warn('Created test redirect rule within `modifyRedirectRule` could not be removed');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should return a redirect rule when setting the url of a redirect rule (partial update) with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const updatedUrl = 'https://construct.or';
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        url: updatedUrl,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('start_time');
+        expect(response).to.have.property('end_time');
+        expect(response).to.have.property('url', updatedUrl);
+        expect(response).to.have.property('matches').that.is.an('array').length(1);
+        expect(response).to.have.property('id').that.is.a('number', addedRedirectRuleId);
+        done();
+      });
+    });
+
+    it('should return a redirect rule when setting the matches of a redirect rule (partial update) with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const updatedMatches = [
+        {
+          match_type: 'EXACT',
+          pattern: 'mallorca',
+        },
+        {
+          match_type: 'EXACT',
+          pattern: 'spain'
+        },
+      ];
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        matches: updatedMatches,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.have.property('matches').that.is.an('array', updatedMatches).length(2);
+        done();
+      });
+    });
+
+    it('should return a redirect rule when setting the start time of a redirect rule (partial update) with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const updatedStartTime = (new Date()).toISOString();
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        start_time: updatedStartTime,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.have.property('start_time');
+        done();
+      });
+    });
+
+    it('should return a redirect rule when setting the end time of a redirect rule (partial update) with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const updatedEndTime = (new Date()).toISOString();
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        end_time: updatedEndTime,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.have.property('end_time');
+        done();
+      });
+    });
+
+    it('should return a redirect rule when setting the user segments of a redirect rule (partial update) with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const updatedUserSegments = ['foo', 'bar'];
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        user_segments: updatedUserSegments,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.have.property('user_segments');
+        done();
+      });
+    });
+
+    it('should return a redirect rule when setting the metadata of a redirect rule (partial update) with valid properties', (done) => {
+      const constructorio = new Constructorio(testConfig);
+      const updatedMetadata = { foo: 'bar' };
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        metadata: updatedMetadata,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.have.property('metadata');
+        done();
+      });
+    });
+
+    it('should return error when partially updating a redirect rule with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        url: 'https://constructor.io',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when setting the matches of a redirect rule without a matches type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        matches: [
+          {
+            pattern: 'constructor'
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'matches[0].match_type is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when setting the matches of a redirect rule without a pattern', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        matches: [
+          {
+            match_type: 'EXACT',
+          },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'matches[0].pattern is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when setting an invalid start time of a redirect rule', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        start_time: 10,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'start_time must be a datetime string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when setting a redirect rule with an an invalid start time', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        end_time: 10,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'end_time must be a datetime string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when setting a redirect rule with an an invalid user settings parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        user_segments: 'abc',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'user_segments must be a list');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when setting a redirect rule with an an invalid metadata', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+        metadata: 'abc',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'metadata must be a dictionary');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('removeRedirectRule', () => {
+    let addedRedirectRuleId = null;
+
+    before((done) => {
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        // Create test redirect rule for use in tests
+        addTestRedirectRule().then((response) => {
+          addedRedirectRuleId = response.id;
+          done();
+        }).catch((err) => {
+          console.warn('Test redirect rule within `removeRedirectRule` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
+    });
+
+    it('should remove a redirect rule for supplied valid redirect rule id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('start_time');
+        expect(response).to.have.property('end_time');
+        expect(response).to.have.property('url');
+        expect(response).to.have.property('matches').that.is.an('array').length(1);
+        expect(response).to.have.property('id').that.is.a('number');
+        done();
+      });
+    });
+
+    it('should return error when removing a redirect rule with non-existent redirect rule id', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeRedirectRule({
+        redirect_rule_id: 0,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'Redirect rule with id 0 not found.');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when removing a redirect rule listing with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.getRedirectRule({
+        redirect_rule_id: addedRedirectRuleId,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
 });

--- a/test/constructorio-redirects.js
+++ b/test/constructorio-redirects.js
@@ -1,4 +1,4 @@
-/* eslint-disable prefer-destructuring, no-unused-expressions, no-console, max-nested-callbacks */
+/* eslint-disable prefer-destructuring, no-unused-expressions */
 
 const expect = require('chai').expect;
 const Constructorio = require('../lib/constructorio');
@@ -49,6 +49,13 @@ function removeTestRedirectRule(id) {
 }
 
 describe('ConstructorIO - Redirect Rules', () => {
+  // Introduce latency to avoid throttling issues
+  beforeEach((done) => {
+    setTimeout(() => {
+      done();
+    }, 100);
+  });
+
   describe('addRedirectRule', () => {
     let addedRedirectRuleIds = [];
 
@@ -62,11 +69,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       // Remove test redirect rules for use in tests
       Promise.all(removePromiseList).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Test redirect rules within `addRedirectRule` could not be created');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should return a redirect rule id when adding a redirect rule with valid properties', (done) => {
@@ -305,20 +308,13 @@ describe('ConstructorIO - Redirect Rules', () => {
     const addedRedirectRuleIds = [];
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        const addPromiseList = [addTestRedirectRule(), addTestRedirectRule(), addTestRedirectRule()];
+      const addPromiseList = [addTestRedirectRule(), addTestRedirectRule(), addTestRedirectRule()];
 
-        // Create test redirect rules for use in tests
-        Promise.all(addPromiseList).then((results) => {
-          results.forEach(result => addedRedirectRuleIds.push(result.id));
-          done();
-        }).catch((err) => {
-          console.warn('Test redirect rules within `getRedirectRules` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test redirect rules for use in tests
+      Promise.all(addPromiseList).then((results) => {
+        results.forEach(result => addedRedirectRuleIds.push(result.id));
+        done();
+      }).catch(done);
     });
 
     after((done) => {
@@ -331,11 +327,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       // Remove test redirect rules for use in tests
       Promise.all(removePromiseList).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Test redirect rules within `getRedirectRules` could not be created');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should retrieve a listing of redirect rules', (done) => {
@@ -486,29 +478,18 @@ describe('ConstructorIO - Redirect Rules', () => {
     let addedRedirectRuleId = null;
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        // Create test redirect rule for use in tests
-        addTestRedirectRule().then((response) => {
-          addedRedirectRuleId = response.id;
-          done();
-        }).catch((err) => {
-          console.warn('Test redirect rule within `getRedirectRule` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test redirect rule for use in tests
+      addTestRedirectRule().then((response) => {
+        addedRedirectRuleId = response.id;
+        done();
+      }).catch(done);
     });
 
     after((done) => {
       // Clean up - remove redirct rule created for tests
       removeTestRedirectRule(addedRedirectRuleId).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Created test redirect rule within `getRedirectRule` could not be removed');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should retrieve a redirect rule for supplied valid redirect rule id', (done) => {
@@ -562,29 +543,18 @@ describe('ConstructorIO - Redirect Rules', () => {
     let addedRedirectRuleId = null;
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        // Create test redirect rule for use in tests
-        addTestRedirectRule().then((response) => {
-          addedRedirectRuleId = response.id;
-          done();
-        }).catch((err) => {
-          console.warn('Test redirect rule within `setRedirectRule` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test redirect rule for use in tests
+      addTestRedirectRule().then((response) => {
+        addedRedirectRuleId = response.id;
+        done();
+      }).catch(done);
     });
 
     after((done) => {
       // Clean up - remove redirct rule created for tests
       removeTestRedirectRule(addedRedirectRuleId).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Created test redirect rule within `setRedirectRule` could not be removed');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should return a redirect rule when completely updating a redirect rule with valid properties', (done) => {
@@ -805,29 +775,18 @@ describe('ConstructorIO - Redirect Rules', () => {
     let addedRedirectRuleId = null;
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        // Create test redirect rule for use in tests
-        addTestRedirectRule().then((response) => {
-          addedRedirectRuleId = response.id;
-          done();
-        }).catch((err) => {
-          console.warn('Test redirect rule within `modifyRedirectRule` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test redirect rule for use in tests
+      addTestRedirectRule().then((response) => {
+        addedRedirectRuleId = response.id;
+        done();
+      }).catch(done);
     });
 
     after((done) => {
       // Clean up - remove redirct rule created for tests
       removeTestRedirectRule(addedRedirectRuleId).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Created test redirect rule within `modifyRedirectRule` could not be removed');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should return a redirect rule when setting the url of a redirect rule (partial update) with valid properties', (done) => {
@@ -1042,18 +1001,11 @@ describe('ConstructorIO - Redirect Rules', () => {
     let addedRedirectRuleId = null;
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        // Create test redirect rule for use in tests
-        addTestRedirectRule().then((response) => {
-          addedRedirectRuleId = response.id;
-          done();
-        }).catch((err) => {
-          console.warn('Test redirect rule within `removeRedirectRule` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test redirect rule for use in tests
+      addTestRedirectRule().then((response) => {
+        addedRedirectRuleId = response.id;
+        done();
+      }).catch(done);
     });
 
     it('should remove a redirect rule for supplied valid redirect rule id', (done) => {

--- a/test/constructorio-redirects.js
+++ b/test/constructorio-redirects.js
@@ -14,7 +14,7 @@ function addTestRedirectRule() {
 
   return new Promise((resolve, reject) => {
     constructorio.addRedirectRule({
-      url: `https://constructor.io`,
+      url: 'https://constructor.io',
       matches: [
         {
           match_type: 'EXACT',
@@ -57,7 +57,7 @@ describe('ConstructorIO - Redirect Rules', () => {
   });
 
   describe('addRedirectRule', () => {
-    let addedRedirectRuleIds = [];
+    const addedRedirectRuleIds = [];
 
     after((done) => {
       const removePromiseList = [];
@@ -180,7 +180,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         url: 'https://constructor.io',
         matches: [
           {
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -218,7 +218,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -238,7 +238,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -258,7 +258,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -278,7 +278,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -345,7 +345,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        num_results_per_page: 1
+        num_results_per_page: 1,
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -358,7 +358,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        num_results_per_page: 'abc'
+        num_results_per_page: 'abc',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'num_results_per_page must be an integer');
@@ -371,7 +371,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        page: 1
+        page: 1,
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -384,7 +384,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        page: 'abc'
+        page: 'abc',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'page must be an integer');
@@ -398,7 +398,7 @@ describe('ConstructorIO - Redirect Rules', () => {
 
       constructorio.getRedirectRules({
         page: 99,
-        num_results_per_page: 1
+        num_results_per_page: 1,
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -411,7 +411,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        query: 'constructor'
+        query: 'constructor',
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -424,7 +424,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        query: 'not-a-valid-query'
+        query: 'not-a-valid-query',
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -437,7 +437,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        status: 'current'
+        status: 'current',
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -450,7 +450,7 @@ describe('ConstructorIO - Redirect Rules', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getRedirectRules({
-        status: 'not-a-valid-status'
+        status: 'not-a-valid-status',
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'Invalid value for parameter: "status"');
@@ -571,7 +571,7 @@ describe('ConstructorIO - Redirect Rules', () => {
           },
           {
             match_type: 'EXACT',
-            pattern: 'spain'
+            pattern: 'spain',
           },
         ],
       }, (err, response) => {
@@ -633,7 +633,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         url: 'https://constructor.io',
         matches: [
           {
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -673,7 +673,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -694,7 +694,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -715,7 +715,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -736,7 +736,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         matches: [
           {
             match_type: 'EXACT',
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {
@@ -817,7 +817,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         },
         {
           match_type: 'EXACT',
-          pattern: 'spain'
+          pattern: 'spain',
         },
       ];
 
@@ -911,7 +911,7 @@ describe('ConstructorIO - Redirect Rules', () => {
         redirect_rule_id: addedRedirectRuleId,
         matches: [
           {
-            pattern: 'constructor'
+            pattern: 'constructor',
           },
         ],
       }, (err, response) => {

--- a/test/constructorio-redirects.js
+++ b/test/constructorio-redirects.js
@@ -14,9 +14,12 @@ function addTestRedirectRule() {
 
   return new Promise((resolve, reject) => {
     constructorio.addRedirectRule({
-      synonyms: [
-        `${Math.random().toString(36).substring(2, 15)}`,
-        `${Math.random().toString(36).substring(2, 15)}`,
+      url: `https://constructor.io`,
+      matches: [
+        {
+          match_type: 'EXACT',
+          pattern: `${Math.random().toString(36).substring(2, 15)}`,
+        },
       ],
     }, (err, response) => {
       if (err) {
@@ -56,11 +59,11 @@ describe('ConstructorIO - Redirect Rules', () => {
         removePromiseList.push(removeTestRedirectRule(redirectRuleId));
       });
 
-      // Remove test synonym groups for use in tests
+      // Remove test redirect rules for use in tests
       Promise.all(removePromiseList).then(() => {
         done();
       }).catch((err) => {
-        console.warn('Test synonym groups within `addRedirectRule` could not be created');
+        console.warn('Test redirect rules within `addRedirectRule` could not be created');
         console.warn(err);
         done();
       });
@@ -285,7 +288,186 @@ describe('ConstructorIO - Redirect Rules', () => {
     });
   });
 
-  describe('getRedirectRules', () => {});
+  describe('getRedirectRules', () => {
+    const addedRedirectRuleIds = [];
+
+    before((done) => {
+      // Introduce latency to avoid throttling issues
+      setTimeout(() => {
+        const addPromiseList = [addTestRedirectRule(), addTestRedirectRule(), addTestRedirectRule()];
+
+        // Create test redirect rules for use in tests
+        Promise.all(addPromiseList).then((results) => {
+          results.forEach(result => addedRedirectRuleIds.push(result.id));
+          done();
+        }).catch((err) => {
+          console.warn('Test redirect rules within `getRedirectRules` could not be created');
+          console.warn(err);
+          done();
+        });
+      }, 3000);
+    });
+
+    after((done) => {
+      const removePromiseList = [];
+
+      addedRedirectRuleIds.forEach((redirectRuleId) => {
+        removePromiseList.push(removeTestRedirectRule(redirectRuleId));
+      });
+
+      // Remove test redirect rules for use in tests
+      Promise.all(removePromiseList).then(() => {
+        done();
+      }).catch((err) => {
+        console.warn('Test redirect rules within `getRedirectRules` could not be created');
+        console.warn(err);
+        done();
+      });
+    });
+
+    it('should retrieve a listing of redirect rules', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({}, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('redirect_rules').an('array');
+        done();
+      });
+    });
+
+    it('should retrieve a listing of one redirect rules when specifying num results per page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        num_results_per_page: 1
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('redirect_rules').an('array').length(1);
+        done();
+      });
+    });
+
+    it('should an error when retrieving a listing of redirect rules with invalid num results per page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        num_results_per_page: 'abc'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'num_results_per_page must be an integer');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should retrieve a listing of one redirect rules when specifying page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        page: 1
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('redirect_rules').an('array');
+        done();
+      });
+    });
+
+    it('should an error when retrieving a listing of redirect rules with invalid page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        page: 'abc'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'page must be an integer');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should retrieve an empty listing of redirect rules when specifying invalid num results per page and page parameters', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        page: 99,
+        num_results_per_page: 1
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('redirect_rules').an('array').length(0);
+        done();
+      });
+    });
+
+    it('should retrieve listing of redirect rules when specifying a valid query parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        query: 'constructor'
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('redirect_rules').an('array');
+        done();
+      });
+    });
+
+    it('should retrieve an empty listing of redirect rules when specifying a non-existent query parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        query: 'not-a-valid-query'
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('redirect_rules').an('array').length(0);
+        done();
+      });
+    });
+
+    it('should retrieve listing of redirect rules when specifying a status', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        status: 'current'
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('redirect_rules').an('array');
+        done();
+      });
+    });
+
+    it('should retrieve an empty listing of redirect rules when specifying an invalid status', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getRedirectRules({
+        status: 'not-a-valid-status'
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'Invalid value for parameter: "status"');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return error when getting group listing with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.getRedirectRules({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
 
   describe('getRedirectRule', () => {});
 

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -311,7 +311,7 @@ describe('ConstructorIO - Synonym Groups', () => {
     it('should retrieve a listing of one group when supplying phrase parameter', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      // Note: Result set is not being checked for match as phrase can take many seconds to be indexed / returned
+      // Note: Result set is not being checked for match as groups can take many seconds to be indexed / returned
       constructorio.getSynonymGroups({
         phrase: firstPhrase,
       }, (err, response) => {
@@ -338,7 +338,7 @@ describe('ConstructorIO - Synonym Groups', () => {
     it('should retrieve a listing of one group when supplying num results per page parameter', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      // Note: Result set is not being checked for match as phrase can take many seconds to be indexed / returned
+      // Note: Result set is not being checked for match as groups can take many seconds to be indexed / returned
       constructorio.getSynonymGroups({
         num_results_per_page: 1,
       }, (err, response) => {

--- a/test/constructorio-synonyms.js
+++ b/test/constructorio-synonyms.js
@@ -1,4 +1,4 @@
-/* eslint-disable prefer-destructuring, no-unused-expressions, no-console, max-nested-callbacks */
+/* eslint-disable prefer-destructuring, no-unused-expressions */
 
 const expect = require('chai').expect;
 const Constructorio = require('../lib/constructorio');
@@ -46,16 +46,19 @@ function removeTestSynonymGroup(id) {
 }
 
 describe('ConstructorIO - Synonym Groups', () => {
+  // Introduce latency to avoid throttling issues
+  beforeEach((done) => {
+    setTimeout(() => {
+      done();
+    }, 100);
+  });
+
   describe('addSynonymGroup', () => {
     let addedSynonymGroupId = null;
 
     after((done) => {
       // Clean up - remove synonym group created for tests
-      removeTestSynonymGroup(addedSynonymGroupId).then(done).catch((err) => {
-        console.warn('Created test synonym group within `addSynonymGroup` could not be removed');
-        console.warn(err);
-        done();
-      });
+      removeTestSynonymGroup(addedSynonymGroupId).then(done).catch(done);
     });
 
     it('should return a group id when adding a group with synonyms', (done) => {
@@ -144,29 +147,18 @@ describe('ConstructorIO - Synonym Groups', () => {
     let addedSynonymGroupId = null;
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        // Create test synonym group for use in tests
-        addTestSynonymGroup().then((response) => {
-          addedSynonymGroupId = response.group_id;
-          done();
-        }).catch((err) => {
-          console.warn('Test synonym group within `modifySynonymGroup` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test synonym group for use in tests
+      addTestSynonymGroup().then((response) => {
+        addedSynonymGroupId = response.group_id;
+        done();
+      }).catch(done);
     });
 
     after((done) => {
       // Clean up - remove synonym group created for tests
       removeTestSynonymGroup(addedSynonymGroupId).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Created test synonym group within `modifySynonymGroup` could not be removed');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should modify a group when supplying a valid group id', (done) => {
@@ -259,20 +251,13 @@ describe('ConstructorIO - Synonym Groups', () => {
     let firstPhrase = '';
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
+      const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
 
-        // Create test synonym groups for use in tests
-        Promise.all(addPromiseList).then((results) => {
-          results.forEach(result => addedSynonymGroupIds.push(result.group_id));
-          done();
-        }).catch((err) => {
-          console.warn('Test synonym groups within `getSynonymGroups` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test synonym groups for use in tests
+      Promise.all(addPromiseList).then((results) => {
+        results.forEach(result => addedSynonymGroupIds.push(result.group_id));
+        done();
+      }).catch(done);
     });
 
     after((done) => {
@@ -285,11 +270,7 @@ describe('ConstructorIO - Synonym Groups', () => {
       // Remove test synonym groups for use in tests
       Promise.all(removePromiseList).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Test synonym groups within `getSynonymGroups` could not be created');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should retrieve a listing of all groups', (done) => {
@@ -408,29 +389,18 @@ describe('ConstructorIO - Synonym Groups', () => {
     let addedSynonymGroupId = null;
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        // Create test synonym group for use in tests
-        addTestSynonymGroup().then((response) => {
-          addedSynonymGroupId = response.group_id;
-          done();
-        }).catch((err) => {
-          console.warn('Test synonym group within `getSynonymGroup` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test synonym group for use in tests
+      addTestSynonymGroup().then((response) => {
+        addedSynonymGroupId = response.group_id;
+        done();
+      }).catch(done);
     });
 
     after((done) => {
       // Clean up - remove synonym group created for tests
       removeTestSynonymGroup(addedSynonymGroupId).then(() => {
         done();
-      }).catch((err) => {
-        console.warn('Created test synonym group within `getSynonymGroup` could not be removed');
-        console.warn(err);
-        done();
-      });
+      }).catch(done);
     });
 
     it('should retrieve a group for supplied valid group id', (done) => {
@@ -489,20 +459,13 @@ describe('ConstructorIO - Synonym Groups', () => {
     const addedSynonymGroupIds = [];
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
+      const addPromiseList = [addTestSynonymGroup(), addTestSynonymGroup(), addTestSynonymGroup()];
 
-        // Create test synonym groups for use in tests
-        Promise.all(addPromiseList).then((results) => {
-          results.forEach(result => addedSynonymGroupIds.push(result.group_id));
-          done();
-        }).catch((err) => {
-          console.warn('Test synonym groups within `getSynonymGroups` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test synonym groups for use in tests
+      Promise.all(addPromiseList).then((results) => {
+        results.forEach(result => addedSynonymGroupIds.push(result.group_id));
+        done();
+      }).catch(done);
     });
 
     it('should start removal of all groups', (done) => {
@@ -549,18 +512,11 @@ describe('ConstructorIO - Synonym Groups', () => {
     let addedSynonymGroupId = null;
 
     before((done) => {
-      // Introduce latency to avoid throttling issues
-      setTimeout(() => {
-        // Create test synonym group for use in tests
-        addTestSynonymGroup().then((response) => {
-          addedSynonymGroupId = response.group_id;
-          done();
-        }).catch((err) => {
-          console.warn('Test synonym group within `removeSynonymGroup` could not be created');
-          console.warn(err);
-          done();
-        });
-      }, 3000);
+      // Create test synonym group for use in tests
+      addTestSynonymGroup().then((response) => {
+        addedSynonymGroupId = response.group_id;
+        done();
+      }).catch(done);
     });
 
     it('should remove a group when supplying a valid group id', (done) => {


### PR DESCRIPTION
Added methods to support the following [redirect rule REST endpoints](https://docs.constructor.io/rest-api.html#redirect-rules):

addRedirectRule => POST https://ac.cnstrc.com/v1/redirect_rules
getRedirectRules => GET https://ac.cnstrc.com/v1/redirect_rules
getRedirectRule => GET https://ac.cnstrc.com/v1/redirect_rules/[redirect_rule_id]
modifyRedirectRule => PUT https://ac.cnstrc.com/v1/redirect_rules/[redirect_rule_id]
updateRedirectRule => PATCH https://ac.cnstrc.com/v1/synonym_groups/[redirect_rule_id]
removeRedirectRule => DELETE https://ac.cnstrc.com/v1/synonym_groups/[redirect_rule_id]

52 tests added covering all methods and associated parameters listed above, executing in ~43 seconds.