### PR TITLE
[CH 7317] One Way Synonyms Support

### DIFF
--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -329,7 +329,7 @@ ConstructorIO.prototype = {
     });
   },
 
-  /*
+  /**
    * @description Retrieves autocomplete results for supplied query
    */
   getAutocompleteResults(params, userParams, callback) {

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -393,14 +393,18 @@ ConstructorIO.prototype = {
     const { phrase } = json;
     delete json.phrase;
 
-    request({
-      method: 'POST',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
-      auth: this.makeAuthToken(),
-      json,
-    }, (error, response) => {
-      handleServerResponse(error, response, callback);
-    });
+    if (phrase) {
+      request({
+        method: 'POST',
+        url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
+        auth: this.makeAuthToken(),
+        json,
+      }, (error, response) => {
+        handleServerResponse(error, response, callback);
+      });
+    } else {
+      handleServerResponse({ message: 'phrase is a required field of type string' }, null, callback);
+    }
   },
 
   /**
@@ -411,14 +415,18 @@ ConstructorIO.prototype = {
     const { phrase } = json;
     delete json.phrase;
 
-    request({
-      method: 'PUT',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
-      auth: this.makeAuthToken(),
-      json,
-    }, (error, response) => {
-      handleServerResponse(error, response, callback);
-    });
+    if (phrase) {
+      request({
+        method: 'PUT',
+        url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
+        auth: this.makeAuthToken(),
+        json,
+      }, (error, response) => {
+        handleServerResponse(error, response, callback);
+      });
+    } else {
+      handleServerResponse({ message: 'phrase is a required field of type string' }, null, callback);
+    }
   },
 
   /**
@@ -456,16 +464,20 @@ ConstructorIO.prototype = {
   getOneWaySynonym(params, callback) {
     const json = clonedeep(params);
     const { phrase } = json;
-    delete json.group_id;
+    delete json.phrase;
 
-    request({
-      method: 'GET',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
-      auth: this.makeAuthToken(),
-      json,
-    }, (error, response) => {
-      handleServerResponse(error, response, callback);
-    });
+    if (phrase) {
+      request({
+        method: 'GET',
+        url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
+        auth: this.makeAuthToken(),
+        json,
+      }, (error, response) => {
+        handleServerResponse(error, response, callback);
+      });
+    } else {
+      handleServerResponse({ message: 'phrase is a required field of type string' }, null, callback);
+    }
   },
 
   /**
@@ -489,14 +501,18 @@ ConstructorIO.prototype = {
     const { phrase } = json;
     delete json.phrase;
 
-    request({
-      method: 'DELETE',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
-      auth: this.makeAuthToken(),
-      json,
-    }, (error, response) => {
-      handleServerResponse(error, response, callback);
-    });
+    if (phrase) {
+      request({
+        method: 'DELETE',
+        url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
+        auth: this.makeAuthToken(),
+        json,
+      }, (error, response) => {
+        handleServerResponse(error, response, callback);
+      });
+    } else {
+      handleServerResponse({ message: 'phrase is a required field of type string' }, null, callback);
+    }
   },
 
 

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -393,7 +393,7 @@ ConstructorIO.prototype = {
     const { phrase } = json;
     delete json.phrase;
 
-    if (phrase) {
+    if (phrase && typeof phrase === 'string') {
       request({
         method: 'POST',
         url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
@@ -415,7 +415,7 @@ ConstructorIO.prototype = {
     const { phrase } = json;
     delete json.phrase;
 
-    if (phrase) {
+    if (phrase && typeof phrase === 'string') {
       request({
         method: 'PUT',
         url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
@@ -466,7 +466,7 @@ ConstructorIO.prototype = {
     const { phrase } = json;
     delete json.phrase;
 
-    if (phrase) {
+    if (phrase && typeof phrase === 'string') {
       request({
         method: 'GET',
         url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
@@ -501,7 +501,7 @@ ConstructorIO.prototype = {
     const { phrase } = json;
     delete json.phrase;
 
-    if (phrase) {
+    if (phrase && typeof phrase === 'string') {
       request({
         method: 'DELETE',
         url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -278,6 +278,120 @@ ConstructorIO.prototype = {
   },
 
   /**
+   * @description Adds a one way synonym.
+   */
+  addOneWaySynonym(params, callback) {
+    const json = clonedeep(params);
+    const { phrase } = json;
+    delete json.phrase;
+
+    request({
+      method: 'POST',
+      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Modifies a one way synonym for supplied parent phrase.
+   */
+  modifyOneWaySynonym(params, callback) {
+    const json = clonedeep(params);
+    const { phrase } = json;
+    delete json.phrase;
+
+    request({
+      method: 'PUT',
+      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Retrieves all one way synonyms.
+   */
+  getOneWaySynonyms(params, callback) {
+    const { num_results_per_page, phrase, page } = params;
+    const qsParams = {};
+
+    if (num_results_per_page) {
+      qsParams.num_results_per_page = num_results_per_page;
+    }
+
+    if (phrase) {
+      qsParams.phrase = phrase;
+    }
+
+    if (page) {
+      qsParams.page = page;
+    }
+
+    request({
+      method: 'GET',
+      url: this.makeUrl('one_way_synonyms'),
+      auth: this.makeAuthToken(),
+      qs: qsParams,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Retrieves a one way synonym for supplied parent phrase.
+   */
+  getOneWaySynonym(params, callback) {
+    const json = clonedeep(params);
+    const { phrase } = json;
+    delete json.group_id;
+
+    request({
+      method: 'GET',
+      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      auth: this.makeAuthToken(),
+      json,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Remove all one way synonyms.
+   */
+  removeOneWaySynonyms(params, callback) {
+    request({
+      method: 'DELETE',
+      url: this.makeUrl('one_way_synonyms'),
+      auth: this.makeAuthToken(),
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
+   * @description Remove a one way synonym for supplied parent phrase.
+   */
+  removeOneWaySynonym(params, callback) {
+    const json = clonedeep(params);
+    const { phrase } = json;
+    delete json.group_id;
+
+    request({
+      method: 'DELETE',
+      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      auth: this.makeAuthToken(),
+      json: params,
+    }, (error, response) => {
+      handleServerResponse(error, response, callback);
+    });
+  },
+
+  /**
    * @description Adds a synonym group.
    */
   addSynonymGroup(params, callback) {

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -96,9 +96,10 @@ ConstructorIO.prototype = {
   /**
    * @description Makes a URL to issue the requests to. Note that the URL will automagically have the apiKey embedded
    */
-  makeUrl(urlPath, appendVersionParameter = true) {
+  makeUrl(urlPath, options) {
+    const configOptions = Object.assign({}, this.config, options);
     // Note: getSynonymGroups and getRedirectRules cannot accept the `c` parameter currently
-    const { protocol, host, basePath, apiKey } = this.config;
+    const { protocol, host, basePath, apiKey, appendVersionParameter } = configOptions;
     const versionParameter = appendVersionParameter ? `&c=${this.config.version}` : '';
 
     return `${protocol}://${host}/${basePath}/${urlPath}?key=${apiKey}${versionParameter}`;
@@ -394,9 +395,9 @@ ConstructorIO.prototype = {
 
     request({
       method: 'POST',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -412,9 +413,9 @@ ConstructorIO.prototype = {
 
     request({
       method: 'PUT',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -441,7 +442,7 @@ ConstructorIO.prototype = {
 
     request({
       method: 'GET',
-      url: this.makeUrl('one_way_synonyms'),
+      url: this.makeUrl('one_way_synonyms', { basePath: 'v2' }),
       auth: this.makeAuthToken(),
       qs: qsParams,
     }, (error, response) => {
@@ -459,7 +460,7 @@ ConstructorIO.prototype = {
 
     request({
       method: 'GET',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
       auth: this.makeAuthToken(),
       json,
     }, (error, response) => {
@@ -473,7 +474,7 @@ ConstructorIO.prototype = {
   removeOneWaySynonyms(params, callback) {
     request({
       method: 'DELETE',
-      url: this.makeUrl('one_way_synonyms'),
+      url: this.makeUrl('one_way_synonyms', { basePath: 'v2' }),
       auth: this.makeAuthToken(),
     }, (error, response) => {
       handleServerResponse(error, response, callback);
@@ -486,13 +487,13 @@ ConstructorIO.prototype = {
   removeOneWaySynonym(params, callback) {
     const json = clonedeep(params);
     const { phrase } = json;
-    delete json.group_id;
+    delete json.phrase;
 
     request({
       method: 'DELETE',
-      url: this.makeUrl(`one_way_synonyms/${phrase}`),
+      url: this.makeUrl(`one_way_synonyms/${phrase}`, { basePath: 'v2' }),
       auth: this.makeAuthToken(),
-      json: params,
+      json,
     }, (error, response) => {
       handleServerResponse(error, response, callback);
     });
@@ -552,7 +553,7 @@ ConstructorIO.prototype = {
 
     request({
       method: 'GET',
-      url: this.makeUrl('synonym_groups', false),
+      url: this.makeUrl('synonym_groups', { appendVersionParameter: false }),
       auth: this.makeAuthToken(),
       qs: qsParams,
     }, (error, response) => {
@@ -570,7 +571,7 @@ ConstructorIO.prototype = {
 
     request({
       method: 'GET',
-      url: this.makeUrl(`synonym_groups/${group_id}`, false),
+      url: this.makeUrl(`synonym_groups/${group_id}`, { appendVersionParameter: false }),
       auth: this.makeAuthToken(),
     }, (error, response) => {
       handleServerResponse(error, response, callback);
@@ -647,7 +648,7 @@ ConstructorIO.prototype = {
 
     request({
       method: 'GET',
-      url: this.makeUrl('redirect_rules', false),
+      url: this.makeUrl('redirect_rules', { appendVersionParameter: false }),
       auth: this.makeAuthToken(),
       qs: qsParams,
     }, (error, response) => {
@@ -665,7 +666,7 @@ ConstructorIO.prototype = {
 
     request({
       method: 'GET',
-      url: this.makeUrl(`redirect_rules/${redirect_rule_id}`, false),
+      url: this.makeUrl(`redirect_rules/${redirect_rule_id}`, { appendVersionParameter: false }),
       auth: this.makeAuthToken(),
     }, (error, response) => {
       handleServerResponse(error, response, callback);

--- a/lib/constructorio.js
+++ b/lib/constructorio.js
@@ -33,7 +33,7 @@ function handleServerResponse(error, response, callback) {
 }
 
 /**
- * @description Creates a constructor.io Client.
+ * @description Creates a constructor.io Client
  */
 function ConstructorIO(config) {
   const { protocol, host, apiToken, apiKey } = config;
@@ -386,7 +386,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Adds a one way synonym.
+   * @description Adds a one way synonym
    */
   addOneWaySynonym(params, callback) {
     const json = clonedeep(params);
@@ -404,7 +404,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Modifies a one way synonym for supplied parent phrase.
+   * @description Modifies a one way synonym for supplied parent phrase
    */
   modifyOneWaySynonym(params, callback) {
     const json = clonedeep(params);
@@ -422,7 +422,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Retrieves all one way synonyms.
+   * @description Retrieves all one way synonyms
    */
   getOneWaySynonyms(params, callback) {
     const { num_results_per_page, phrase, page } = params;
@@ -451,7 +451,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Retrieves a one way synonym for supplied parent phrase.
+   * @description Retrieves a one way synonym for supplied parent phrase
    */
   getOneWaySynonym(params, callback) {
     const json = clonedeep(params);
@@ -469,7 +469,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Remove all one way synonyms.
+   * @description Remove all one way synonyms
    */
   removeOneWaySynonyms(params, callback) {
     request({
@@ -482,7 +482,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Remove a one way synonym for supplied parent phrase.
+   * @description Remove a one way synonym for supplied parent phrase
    */
   removeOneWaySynonym(params, callback) {
     const json = clonedeep(params);
@@ -579,7 +579,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Remove all synonym groups.
+   * @description Remove all synonym groups
    */
   removeSynonymGroups(params, callback) {
     request({
@@ -610,7 +610,7 @@ ConstructorIO.prototype = {
   },
 
   /**
-   * @description Creates a redirect rule.
+   * @description Creates a redirect rule
    */
   addRedirectRule(params, callback) {
     request({

--- a/test/constructorio-synonyms-one-way.js
+++ b/test/constructorio-synonyms-one-way.js
@@ -324,7 +324,10 @@ describe('ConstructorIO - One Way Synonyms', () => {
     it('should retrieve a listing of one way synonyms when supplying a phrase', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      // Note: Result set is not being checked for match as one way synonyms can take many seconds to be indexed / returned
+      /**
+       * Note: Result set is not being checked for match as one way synonyms
+       * can take many seconds to be indexed / returned
+       */
       constructorio.getOneWaySynonyms({
         phrase: 'spices',
       }, (err, response) => {
@@ -351,7 +354,10 @@ describe('ConstructorIO - One Way Synonyms', () => {
     it('should retrieve a listing of one way synonyms when supplying a num results per page', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      // Note: Result set is not being checked for match as one way synonyms can take many seconds to be indexed / returned
+      /**
+       * Note: Result set is not being checked for match as one way synonyms
+       * can take many seconds to be indexed / returned
+       */
       constructorio.getOneWaySynonyms({
         num_results_per_page: 1,
       }, (err, response) => {

--- a/test/constructorio-synonyms-one-way.js
+++ b/test/constructorio-synonyms-one-way.js
@@ -44,7 +44,7 @@ function removeTestOneWaySynonym(phrase) {
   });
 }
 
-describe.only('ConstructorIO - One Way Synonyms', () => {
+describe('ConstructorIO - One Way Synonyms', () => {
   // Introduce latency to avoid throttling issues
   beforeEach((done) => {
     setTimeout(() => {

--- a/test/constructorio-synonyms-one-way.js
+++ b/test/constructorio-synonyms-one-way.js
@@ -1,0 +1,587 @@
+/* eslint-disable prefer-destructuring, no-unused-expressions */
+
+const expect = require('chai').expect;
+const Constructorio = require('../lib/constructorio');
+
+const testConfig = {
+  apiToken: 'YSOxV00F0Kk2R0KnPQN8',
+  apiKey: 'ZqXaOfXuBWD4s3XzCI1q',
+};
+
+// Helper method - create one way synonym with a random parent phrase and child phrases
+function addTestOneWaySynonym(phrase) {
+  const constructorio = new Constructorio(testConfig);
+
+  return new Promise((resolve, reject) => {
+    constructorio.addOneWaySynonym({
+      phrase,
+      child_phrases: [
+        { phrase: `${Math.random().toString(36).substring(2, 15)}` },
+        { phrase: `${Math.random().toString(36).substring(2, 15)}` },
+      ],
+    }, (err, response) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(response);
+    });
+  });
+}
+
+// Helper method - remove one way synonym for specified parent phrase
+function removeTestOneWaySynonym(phrase) {
+  const constructorio = new Constructorio(testConfig);
+
+  return new Promise((resolve, reject) => {
+    constructorio.removeOneWaySynonym({
+      phrase,
+    }, (err, response) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(response);
+    });
+  });
+}
+
+describe.only('ConstructorIO - One Way Synonyms', () => {
+  // Introduce latency to avoid throttling issues
+  beforeEach((done) => {
+    setTimeout(() => {
+      done();
+    }, 200);
+  });
+
+  describe('addOneWaySynonym', () => {
+    const oneWaySynonymPhrase = 'cheese';
+
+    after((done) => {
+      // Clean up test one way synonyms
+      removeTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
+    });
+
+    it('should add a one way synonym', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+        child_phrases: [
+          { phrase: 'parmesan' },
+          { phrase: 'gouda' },
+          { phrase: 'mozzarella' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying a phrase that already exists', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+        child_phrases: [
+          { phrase: 'parmesan' },
+          { phrase: 'gouda' },
+          { phrase: 'mozzarella' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'A one way synonym with the parent phrase "cheese" already exists.');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying child phrases of incorrect type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+        child_phrases: 'pizza',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'child_phrases must be a list');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when not supplying a child phrases property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addOneWaySynonym({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'child_phrases is a required field of type list');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.addOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+        child_phrases: [
+          { phrase: 'parmesan' },
+          { phrase: 'gouda' },
+          { phrase: 'mozzarella' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('modifyOneWaySynonym', () => {
+    const oneWaySynonymPhrase = 'bread';
+
+    before((done) => {
+      // Create test one way synonyms for use in tests
+      setTimeout(() => {
+        addTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
+      }, 100);
+    });
+
+    after((done) => {
+      // Clean up test one way synonyms
+      removeTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
+    });
+
+    it('should modify a one way synonym', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+        child_phrases: [
+          { phrase: 'loaf' },
+          { phrase: 'buns' },
+          { phrase: 'toast' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyOneWaySynonym({
+        phrase: 1,
+        child_phrases: [
+          { phrase: 'loaf' },
+          { phrase: 'buns' },
+          { phrase: 'toast' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no one way synonym with "1" as a parent phrase');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying child phrases of incorrect type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+        child_phrases: 'foo',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'child_phrases must be a list');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when not supplying a child phrases property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'child_phrases is a required field of type list');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when not supplying a phrase parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyOneWaySynonym({
+        child_phrases: [
+          { phrase: 'loaf' },
+          { phrase: 'buns' },
+          { phrase: 'toast' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no one way synonym with "undefined" as a parent phrase');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.modifyOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+        child_phrases: [
+          { phrase: 'loaf' },
+          { phrase: 'buns' },
+          { phrase: 'toast' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('getOneWaySynonyms', () => {
+    const oneWaySynonymPhrases = ['spices', 'utensils', 'snacks'];
+
+    before((done) => {
+      const addPromiseList = oneWaySynonymPhrases.map(addTestOneWaySynonym);
+
+      // Create test one way synonyms for use in tests
+      Promise.all(addPromiseList).then(() => done()).catch(() => done());
+    });
+
+    after((done) => {
+      const removePromiseList = oneWaySynonymPhrases.map(removeTestOneWaySynonym);
+
+      // Clean up test one way synonyms
+      Promise.all(removePromiseList).then(() => done()).catch(() => done());
+    });
+
+    it('should retrieve a listing of all one way synonyms', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonyms({}, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').to.be.an('array').length(3);
+        done();
+      });
+    });
+
+    it('should retrieve a listing of one way synonyms when supplying a phrase property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      // Note: Result set is not being checked for match as groups can take many seconds to be indexed / returned
+      constructorio.getOneWaySynonyms({
+        phrase: 'spices',
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').to.be.an('array');
+        done();
+      });
+    });
+
+    it('should return no results when supplying a non-existent phrase property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonyms({
+        phrase: 'mallorca',
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').an('array').length(0);
+        done();
+      });
+    });
+
+    it('should retrieve a listing of one way synonyms when supplying num results per page property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      // Note: Result set is not being checked for match as groups can take many seconds to be indexed / returned
+      constructorio.getOneWaySynonyms({
+        num_results_per_page: 1,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').an('array');
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid num results per page property', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonyms({
+        num_results_per_page: 'abc',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'num_results_per_page must be an integer');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return no results when supplying an invalid num results per page and page combination', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonyms({
+        num_results_per_page: 1,
+        page: 7,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').an('array').length(0);
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid page parameter', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonyms({
+        page: 'abc',
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'page must be an integer');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.getOneWaySynonyms({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('getOneWaySynonym', () => {
+    const oneWaySynonymPhrase = 'condiments';
+
+    before((done) => {
+      // Create test one way synonyms for use in tests
+      addTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
+    });
+
+    after((done) => {
+      // Clean up test one way synonyms
+      removeTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
+    });
+
+    it('should retrieve a list of one way synonyms when supplying a valid phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').an('array').length(1);
+        done();
+      });
+    });
+
+    it('should return no results when supplying a non-existent phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonym({
+        phrase: 1,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').an('array').length(0);
+        done();
+      });
+    });
+
+    it('should return no results when not supplying a phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonym({}, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('one_way_synonym_relations').an('array').length(0);
+        done();
+      });
+    });
+
+    it('should return an error when supplying an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.getOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('removeOneWaySynonyms', () => {
+    const oneWaySynonymPhrases = ['spices', 'utensils', 'snacks'];
+
+    before((done) => {
+      const addPromiseList = oneWaySynonymPhrases.map(addTestOneWaySynonym);
+
+      // Create test one way synonyms for use in tests
+      Promise.all(addPromiseList).then(() => done()).catch(() => done());
+    });
+
+    after((done) => {
+      const removePromiseList = oneWaySynonymPhrases.map(removeTestOneWaySynonym);
+
+      // Clean up test one way synonyms
+      Promise.all(removePromiseList).then(() => done()).catch(() => done());
+    });
+
+    it('should start removal of all one way synonyms', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeOneWaySynonyms({}, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.an('object');
+        expect(response).to.have.property('message', 'We\'ve started deleting all of your synonym groups. This may take some time to complete.');
+        done();
+      });
+    });
+
+    it('should notify that all one way synonyms have already been deleted', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      // It can take some time for the system to remove all items
+      setTimeout(() => {
+        constructorio.removeOneWaySynonyms({}, (err, response) => {
+          expect(err).to.be.undefined;
+          expect(response).to.be.an('object');
+          expect(response).to.have.property('message', 'It appears there aren\'t any items to delete');
+          done();
+        });
+      }, 3000);
+    });
+
+    it('should return an error when removing one way synonyms with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.removeOneWaySynonyms({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+
+  describe('removeOneWaySynonym', () => {
+    const oneWaySynonymPhrase = 'berries';
+
+    before((done) => {
+      // Create test one way synonyms for use in tests
+      addTestOneWaySynonym(oneWaySynonymPhrase).then(() => done()).catch(() => done());
+    });
+
+    after((done) => {
+      // Clean up test one way synonyms
+      removeTestOneWaySynonym(oneWaySynonymPhrase).then(() => done()).catch(() => done());
+    });
+
+    it('should remove a one way synonym when supplying a valid phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+      }, (err, response) => {
+        expect(err).to.be.undefined;
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying a valid one way synonym that has already been removed', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no one way synonym with "berries" as a parent phrase');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying a phrase of invalid type', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeOneWaySynonym({
+        phrase: 1,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no one way synonym with "1" as a parent phrase');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when not supplying a phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.removeOneWaySynonym({}, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'There is no one way synonym with "undefined" as a parent phrase');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when adding a one way synonym with an invalid key/token', (done) => {
+      const constructorio = new Constructorio({
+        apiToken: 'bad-token',
+        apiKey: 'bad-key',
+      });
+
+      constructorio.removeOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message').to.match(/You have supplied an invalid/);
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+  });
+});

--- a/test/constructorio-synonyms-one-way.js
+++ b/test/constructorio-synonyms-one-way.js
@@ -77,6 +77,24 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
+    it('should return an error when supplying an invalid phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addOneWaySynonym({
+        phrase: 1,
+        child_phrases: [
+          { phrase: 'loaf' },
+          { phrase: 'buns' },
+          { phrase: 'toast' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
     it('should return an error when supplying a phrase that already exists', (done) => {
       const constructorio = new Constructorio(testConfig);
 
@@ -95,7 +113,24 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return an error when supplying child phrases of incorrect type', (done) => {
+    it('should return an error when not supplying a phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.addOneWaySynonym({
+        child_phrases: [
+          { phrase: 'parmesan' },
+          { phrase: 'gouda' },
+          { phrase: 'mozzarella' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying a child phrases of incorrect type', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.addOneWaySynonym({
@@ -109,10 +144,12 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return an error when not supplying a child phrases property', (done) => {
+    it('should return an error when not supplying a child phrases', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      constructorio.addOneWaySynonym({}, (err, response) => {
+      constructorio.addOneWaySynonym({
+        phrase: oneWaySynonymPhrase,
+      }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'child_phrases is a required field of type list');
         expect(response).to.be.undefined;
@@ -147,9 +184,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
 
     before((done) => {
       // Create test one way synonyms for use in tests
-      setTimeout(() => {
-        addTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
-      }, 100);
+      addTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
     });
 
     after((done) => {
@@ -186,13 +221,30 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
         ],
       }, (err, response) => {
         expect(err).to.be.an('object');
-        expect(err).to.have.property('message', 'There is no one way synonym with "1" as a parent phrase');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
         expect(response).to.be.undefined;
         done();
       });
     });
 
-    it('should return an error when supplying child phrases of incorrect type', (done) => {
+    it('should return an error when not supplying a phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.modifyOneWaySynonym({
+        child_phrases: [
+          { phrase: 'loaf' },
+          { phrase: 'buns' },
+          { phrase: 'toast' },
+        ],
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when supplying a child phrases of incorrect type', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.modifyOneWaySynonym({
@@ -206,7 +258,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return an error when not supplying a child phrases property', (done) => {
+    it('should return an error when not supplying a child phrases', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.modifyOneWaySynonym({
@@ -214,23 +266,6 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       }, (err, response) => {
         expect(err).to.be.an('object');
         expect(err).to.have.property('message', 'child_phrases is a required field of type list');
-        expect(response).to.be.undefined;
-        done();
-      });
-    });
-
-    it('should return an error when not supplying a phrase parameter', (done) => {
-      const constructorio = new Constructorio(testConfig);
-
-      constructorio.modifyOneWaySynonym({
-        child_phrases: [
-          { phrase: 'loaf' },
-          { phrase: 'buns' },
-          { phrase: 'toast' },
-        ],
-      }, (err, response) => {
-        expect(err).to.be.an('object');
-        expect(err).to.have.property('message', 'There is no one way synonym with "undefined" as a parent phrase');
         expect(response).to.be.undefined;
         done();
       });
@@ -286,10 +321,10 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should retrieve a listing of one way synonyms when supplying a phrase property', (done) => {
+    it('should retrieve a listing of one way synonyms when supplying a phrase', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      // Note: Result set is not being checked for match as groups can take many seconds to be indexed / returned
+      // Note: Result set is not being checked for match as one way synonyms can take many seconds to be indexed / returned
       constructorio.getOneWaySynonyms({
         phrase: 'spices',
       }, (err, response) => {
@@ -300,7 +335,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return no results when supplying a non-existent phrase property', (done) => {
+    it('should return no results when supplying a non-existent phrase', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getOneWaySynonyms({
@@ -313,10 +348,10 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should retrieve a listing of one way synonyms when supplying num results per page property', (done) => {
+    it('should retrieve a listing of one way synonyms when supplying a num results per page', (done) => {
       const constructorio = new Constructorio(testConfig);
 
-      // Note: Result set is not being checked for match as groups can take many seconds to be indexed / returned
+      // Note: Result set is not being checked for match as one way synonyms can take many seconds to be indexed / returned
       constructorio.getOneWaySynonyms({
         num_results_per_page: 1,
       }, (err, response) => {
@@ -327,7 +362,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return an error when supplying an invalid num results per page property', (done) => {
+    it('should return an error when supplying an invalid num results per page', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getOneWaySynonyms({
@@ -354,7 +389,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return an error when supplying an invalid page parameter', (done) => {
+    it('should return an error when supplying an invalid page', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getOneWaySynonyms({
@@ -395,7 +430,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       removeTestOneWaySynonym(oneWaySynonymPhrase).then(done).catch(done);
     });
 
-    it('should retrieve a list of one way synonyms when supplying a valid phrase', (done) => {
+    it('should retrieve a list of one way synonyms', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getOneWaySynonym({
@@ -412,7 +447,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getOneWaySynonym({
-        phrase: 1,
+        phrase: 'shoes',
       }, (err, response) => {
         expect(err).to.be.undefined;
         expect(response).to.be.an('object');
@@ -421,13 +456,26 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return no results when not supplying a phrase', (done) => {
+    it('should return an error when supplying an invalid phrase', (done) => {
+      const constructorio = new Constructorio(testConfig);
+
+      constructorio.getOneWaySynonym({
+        phrase: 1,
+      }, (err, response) => {
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
+        expect(response).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should return an error when not supplying a phrase', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.getOneWaySynonym({}, (err, response) => {
-        expect(err).to.be.undefined;
-        expect(response).to.be.an('object');
-        expect(response).to.have.property('one_way_synonym_relations').an('array').length(0);
+        expect(err).to.be.an('object');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
+        expect(response).to.be.undefined;
         done();
       });
     });
@@ -519,7 +567,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       removeTestOneWaySynonym(oneWaySynonymPhrase).then(() => done()).catch(() => done());
     });
 
-    it('should remove a one way synonym when supplying a valid phrase', (done) => {
+    it('should remove a one way synonym', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.removeOneWaySynonym({
@@ -531,7 +579,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return an error when supplying a valid one way synonym that has already been removed', (done) => {
+    it('should return an error when supplying a valid phrase that has already been removed', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.removeOneWaySynonym({
@@ -544,14 +592,14 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
       });
     });
 
-    it('should return an error when supplying a phrase of invalid type', (done) => {
+    it('should return an error when supplying an invalid phrase', (done) => {
       const constructorio = new Constructorio(testConfig);
 
       constructorio.removeOneWaySynonym({
         phrase: 1,
       }, (err, response) => {
         expect(err).to.be.an('object');
-        expect(err).to.have.property('message', 'There is no one way synonym with "1" as a parent phrase');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
         expect(response).to.be.undefined;
         done();
       });
@@ -562,7 +610,7 @@ describe.only('ConstructorIO - One Way Synonyms', () => {
 
       constructorio.removeOneWaySynonym({}, (err, response) => {
         expect(err).to.be.an('object');
-        expect(err).to.have.property('message', 'There is no one way synonym with "undefined" as a parent phrase');
+        expect(err).to.have.property('message', 'phrase is a required field of type string');
         expect(response).to.be.undefined;
         done();
       });


### PR DESCRIPTION
* Update `makeUrl` to take an options object
* Add support for One Way Synonyms
* Add tests around One Way Synonyms

Notes:
Still missing a test case around having an empty `child_phrases` array, but should be ready overall and mergeable. Can always add it in later when the issue is resolved.

Discussion about the above here: https://constructor.slack.com/archives/CA44G41HA/p1568830253012600